### PR TITLE
Add FoxWallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,3 +227,4 @@ The following is a curated list of applications powered by Aleo.
 - [Avail](https://avail.global) - A mobile wallet on Aleo focused on enabling real world use of private self custody.
 - [Coffer](https://github.com/coffer-aleo/coffer-wallet) - Multisig Smart Contract Wallet on Aleo
 - [MetaMask Snap (Official)](https://snaps.metamask.io/snap/npm/chainsafe/aleo-snap/) - Official MetaMask Snap for Aleo
+- [FoxWallet](https://foxwallet.com/) - A user-friendly wallet for Aleo

--- a/README.ua.md
+++ b/README.ua.md
@@ -186,3 +186,4 @@
 - [(Unofficial) Account SDK](https://github.com/qqmee/aleo-sdk) - Неофіційний SDK для облікового запису Aleo
 - [Leo Wallet](https://leo.app/) - Простий і приватний гаманець для Aleo. Зараз відкрито ранній доступ до списку очікування.
 - [Leo Wallet Adapter SDK](https://github.com/demox-labs/aleo-wallet-adapter) - SDK для інтеграції з гаманцем Leo
+- [FoxWallet](https://foxwallet.com/) - Удобный кошелек для Aleo


### PR DESCRIPTION
Hi, PR from FoxWallet team.
FoxWallet is the most popular Aleo wallet in China, and here's our doc: https://hc.foxwallet.com/docs/aleo/.
And the FoxWallet Extension is full open source https://github.com/foxwallet/foxwallet-extension.
<img width="464" alt="image" src="https://github.com/user-attachments/assets/e79b8511-ad28-435c-8a4d-a89a7d071ace">

